### PR TITLE
Simplify Kotlin LSP setup and enable inlay hints

### DIFF
--- a/brain/nvim/init.lua
+++ b/brain/nvim/init.lua
@@ -228,11 +228,7 @@ require('lazy').setup({
           'html',         -- HTML
           'cssls',        -- CSS
           'bashls',       -- Bash
-        },
-        -- Automatically enable installed servers via vim.lsp.enable()
-        -- kotlin_lsp is excluded because kotlin.nvim manages it directly
-        automatic_enable = {
-          exclude = { 'kotlin_lsp' },
+          'kotlin_lsp',   -- Kotlin (JetBrains official, Mason package: kotlin-lsp)
         },
       })
     end,
@@ -324,35 +320,12 @@ require('lazy').setup({
           vim.keymap.set('n', ']d', vim.diagnostic.goto_next, vim.tbl_extend('force', opts, { desc = 'Next Diagnostic' }))
           vim.keymap.set('n', '<leader>e', vim.diagnostic.open_float, vim.tbl_extend('force', opts, { desc = 'Show Diagnostic' }))
           vim.keymap.set('n', '<leader>q', vim.diagnostic.setloclist, vim.tbl_extend('force', opts, { desc = 'Diagnostic List' }))
+          -- Inlay hints (enable for servers that support it)
+          local client = vim.lsp.get_client_by_id(ev.data.client_id)
+          if client and client.server_capabilities.inlayHintProvider then
+            vim.lsp.inlay_hint.enable(true, { bufnr = ev.buf })
+          end
         end,
-      })
-    end,
-  },
-
-  -- ---------------------------------------------------------------------------
-  -- Kotlin LSP (JetBrains Official kotlin-lsp via kotlin.nvim)
-  -- ---------------------------------------------------------------------------
-  {
-    'AlexandrosAlexiou/kotlin.nvim',
-    ft = { 'kotlin' },
-    dependencies = {
-      'williamboman/mason.nvim',
-      'williamboman/mason-lspconfig.nvim',
-      'stevearc/oil.nvim',
-      'folke/trouble.nvim',
-    },
-    config = function()
-      require('kotlin').setup({
-        root_markers = { 'gradlew', 'mvnw', '.git' },
-        inlay_hints = {
-          enabled = true,
-          parameters = true,
-          types_property = true,
-          types_variable = true,
-          function_return = true,
-          function_parameter = true,
-          lambda_return = true,
-        },
       })
     end,
   },


### PR DESCRIPTION
# Pull Request

## 概要 / Summary
Kotlin LSP設定を簡素化し、mason-lspconfigで直接管理するように変更しました。また、LSP inlay hintsをサポートするサーバーに対して自動的に有効化する機能を追加しました。

## 変更内容 / Changes

- **Kotlin LSP管理の統一**: `kotlin.nvim`プラグインを削除し、Kotlin LSPを`mason-lspconfig`の管理下に統合
  - `automatic_enable`の除外リストから`kotlin_lsp`を削除
  - `servers`リストに`kotlin_lsp`を直接追加
  
- **Inlay Hints自動有効化**: LSP接続時にサーバーがinlay hint機能をサポートしている場合、自動的に有効化
  - `LspAttach`イベントハンドラーにinlay hint有効化ロジックを追加
  - サーバー機能の確認後、条件付きで有効化

- **設定簡素化**: Kotlin固有の複雑な設定（`kotlin.nvim`の`inlay_hints`オプション）を削除し、LSP標準の仕組みに統一

## テスト / Testing

- [x] Neovim起動時にエラーが発生しないことを確認
- [x] Kotlinファイル編集時にLSPが正常に動作することを確認
- [x] Inlay hintsが表示されることを確認

## 関連Issue / Related Issues

N/A

## その他 / Additional Notes

この変更により、Kotlin LSPの管理がシンプルになり、他のLSPと同じ方式で統一されます。`kotlin.nvim`の複雑な設定は不要になり、LSP標準のinlay hint機能を活用します。

https://claude.ai/code/session_01ABUiLPUM3ACKgxwqTjboxr